### PR TITLE
Minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ remote_syslog.init.d. You may be able to:
 
 ## Configuration
 
+By default, the gem looks for a configuration in /etc/log_files.yml.
+
 The gem comes with a sample config.  Optionally:
 
     cp examples/log_files.yml.example /etc/log_files.yml
@@ -75,6 +77,10 @@ to log to (as a hash).  Only 1 destination server is supported; the command-line
 argument wins.  Filenames given on the command line are additive to those 
 in the config file.
 
+    files: [/var/log/httpd/access_log, /var/log/httpd/error_log, /var/log/mysqld.log, /var/run/mysqld/mysqld-slow.log]
+    destination:
+      host: logs.papertrailapp.com
+      port: 12345
 
 ## Contribute
 

--- a/bin/remote_syslog
+++ b/bin/remote_syslog
@@ -87,8 +87,14 @@ def remote_syslog_daemon(args)
     exit
   end
 
-  # handle relative paths before Daemonize changes the wd to /
-  files.map! { |f| File.expand_path(f) }
+  # handle relative paths before Daemonize changes the wd to / and expand wildcards
+  files.map! { |f| File.expand_path(f) }.delete_if { |f|
+    if f.include? '*'
+      Dir.glob(f) { |e| files.push e; }
+      true
+    end
+  }
+  files.uniq!
 
   Daemons.run_proc(daemonize_options[:app_name], daemonize_options) do
     EventMachine.run do


### PR DESCRIPTION
The link within the Papertrail app, sends you to rubygems. If you read the documentation (README.md), it references a sample configuration file which you don't see [easily] unless you look at the github source, so I rolled that sample into the README file.

Secondly, bin/remote_syslog didn't expand wildcards, so I'd have to type out every log file (I have an Apache directory with 100s of log files). I changed it to expand wildcards, and then throw duplicate elements out of the array (in case you were redundant and specified both the file and a matching wildcard).

Enjoy!
-oo
