### PR TITLE
Honor command-line arguments as higher priority than config file options.

### DIFF
--- a/bin/remote_syslog
+++ b/bin/remote_syslog
@@ -67,6 +67,8 @@ def remote_syslog_daemon(args)
     end
   end
   
+  op.parse!
+  
   files = ARGV
   if File.exist?(options[:configfile])
     config = open(options[:configfile]) do |f|
@@ -75,18 +77,15 @@ def remote_syslog_daemon(args)
     
     files += config['files']
     if config['destination']
-      options[:dest_host] = config['destination']['host'] if config['destination']['host']
-      options[:dest_port] = config['destination']['port'] if config['destination']['port']
+      options[:dest_host] = config['destination']['host'] if config['destination']['host'] && !options[:dest_host]
+      options[:dest_port] = config['destination']['port'] if config['destination']['port'] && !options[:dest_host]
     end
-  end
-  if files.empty?
+  elsif files.empty?
     puts "No filenames provided and #{options[:configfile]} not found."
     puts ''
     puts op
     exit
   end
-  
-  op.parse!
 
   # handle relative paths before Daemonize changes the wd to / and expand wildcards
   files = files.map { |f| Dir.glob(f) }.flatten.map { |f| File.expand_path(f) }.uniq


### PR DESCRIPTION
Honor command-line arguments as higher priority than config file options. Thanks to @joevandyk and @tanga for encountering this bug.
