### PR TITLE
Adding ability to set a custom hostname from YAML

### DIFF
--- a/bin/remote_syslog
+++ b/bin/remote_syslog
@@ -106,7 +106,8 @@ def remote_syslog_daemon(args)
           EventMachine::file_tail(File.expand_path(path), RemoteSyslog::Reader, 
             options[:dest_host], options[:dest_port],
             :socket => socket, :facility => options[:facility],
-            :severity => options[:severity], :strip_color => options[:strip_color])
+            :severity => options[:severity], :strip_color => options[:strip_color],
+            :hostname => options[:hostname])
                                   
         rescue Errno::ENOENT => e
           puts "#{File.expand_path(path)} not found, continuing. (#{e.message})"


### PR DESCRIPTION
Noticed the ability to set a custom hostname in reader.rb, so I thought I would allow the option to be parsed in from the YAML configuration  
I have tested this, and it works :cake:

Thx,
Luke
