### PR TITLE
EY syslog has spaces where the syslog regex expects zeros

### DIFF
--- a/lib/remote_syslog/cli.rb
+++ b/lib/remote_syslog/cli.rb
@@ -7,7 +7,7 @@ require 'daemons'
 module RemoteSyslog
   class Cli
     FIELD_REGEXES = {
-      'syslog' => /^(\w+ \d+ \S+) (\w+) ([^: ]+):? (.*)$/,
+      'syslog' => /^(\w+ +\d+ \S+) (\w+) ([^: ]+):? (.*)$/,
       'rfc3339' => /^(\S+) (\w+) ([^: ]+):? (.*)$/
     }
 


### PR DESCRIPTION
This fixes it by simply allowing more spaces inside the match. I checked, and `Time.parse` has no problem with extra spaces.
