### PR TITLE
Allow multiple instances

### DIFF
--- a/lib/remote_syslog/cli.rb
+++ b/lib/remote_syslog/cli.rb
@@ -30,6 +30,7 @@ module RemoteSyslog
         :dir_mode     => :system,
         :backtrace    => false,
         :monitor      => false,
+        :multiple     => true
       }
     end
 


### PR DESCRIPTION
I receive the following error when I try to run multiple instance (with different PID files):

ERROR: there is already one or more instance(s) of the program running

I dug into the Daemons source and it looks like you just need to pass :multiple => true to allow this. I tested locally and was able to run multiple instances. 

It's a one line fix so hopefully you can pull it in without any issues.

Best,
Matt
