### PR TITLE
example upstart config file

### DIFF
--- a/examples/remote_syslog.upstart.conf
+++ b/examples/remote_syslog.upstart.conf
@@ -1,0 +1,7 @@
+description "Monitor files and send to remote syslog"
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+pre-start exec /usr/bin/test -e /etc/log_files.yml
+
+exec /var/lib/gems/1.8/bin/remote_syslog -D --tls


### PR DESCRIPTION
copy file to /etc/init/remote_syslog.conf

ln -s /lib/init/upstart-job /etc/init.d/remote_syslog

(example for Ubuntu)
