### PR TITLE
Make example init.d script secure by default

### DIFF
--- a/examples/remote_syslog.init.d
+++ b/examples/remote_syslog.init.d
@@ -13,7 +13,7 @@ prog="remote_syslog"
 config="/etc/log_files.yml"
 pid_dir="/var/run"
 
-EXTRAOPTIONS=""
+EXTRAOPTIONS="--tls"
 
 pid_file="$pid_dir/$prog.pid"
 


### PR DESCRIPTION
Remote systems should be using secure values by default. 

Sane defaults are always good

Also this fits in line with the upstart example script.
