### PR TITLE
update upstart script so that it respawns the process

### DIFF
--- a/examples/remote_syslog.upstart.conf
+++ b/examples/remote_syslog.upstart.conf
@@ -2,6 +2,8 @@ description "Monitor files and send to remote syslog"
 start on runlevel [2345]
 stop on runlevel [!2345]
 
+respawn
+
 pre-start exec /usr/bin/test -e /etc/log_files.yml
 
 exec /var/lib/gems/1.8/bin/remote_syslog -D --tls


### PR DESCRIPTION
In some cases the remote_syslog process crashes, and if there is no respawn, it stays stopped, and we may loose logs, alerts, ... Auto-respawn seems to be the right "default" behavior for such a service.
