### PR TITLE
Exit codes for status command are not compliant

### DIFF
--- a/examples/remote_syslog.init.d
+++ b/examples/remote_syslog.init.d
@@ -62,9 +62,12 @@ status(){
 
     if (is_running); then
       echo "found"
+      RETVAL=0
     else
       echo "not found"
+      RETVAL=1
     fi
+    return $RETVAL
 }
 
 reload(){


### PR DESCRIPTION
See - http://refspecs.linuxbase.org/LSB_3.1.1/LSB-Core-generic/LSB-Core-generic/iniscrptact.html

The status action is required to return an exit code of `0` if the service is running. If the service is not running a non-zero code is required.
